### PR TITLE
add avg loss

### DIFF
--- a/trl/trainer/moreh_utils.py
+++ b/trl/trainer/moreh_utils.py
@@ -19,7 +19,9 @@ class TBTrainerCallback(TrainerCallback):
             self.start_time = time.time()
 
     def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
-        self.epoch_loss_list.append(state.log_history[-1]["loss"])
+        latest_lost = state.log_history[-1].get("loss", None)
+        if latest_lost is not None:
+            self.epoch_loss_list.append(latest_lost)
 
     def on_log(self, args: TrainingArguments, state: TrainerState, control: TrainerControl,**kwargs):
         if args.logging_strategy == 'steps':

--- a/trl/trainer/moreh_utils.py
+++ b/trl/trainer/moreh_utils.py
@@ -42,6 +42,7 @@ class TBTrainerCallback(TrainerCallback):
         # calculate average loss of epoch
         epoch_loss = sum(self.epoch_loss_list) / len(self.epoch_loss_list)
         mlflow.log_metric("epoch_loss", epoch_loss, step=state.epoch)
+        self.epoch_loss_list = []
 
 
 # Log number of parameters function


### PR DESCRIPTION
Reason: For some models, the loss fluctuates a lot. This means comparing the loss of the last batch of any epoch to the baseline gives unreliable results.

This PR measures the average loss across batches of 1 epoch and log to mlflow