### PR TITLE
Update requirements_moreh.txt

### DIFF
--- a/requirements_moreh.txt
+++ b/requirements_moreh.txt
@@ -1,1 +1,8 @@
+datasets>=1.17.0
+diffusers>=0.21.2
+tqdm==4.65.2
+transformers==4.29.2
+accelerate==0.21.0
+peft==0.5.0
+tyro>=0.5.7
 -e .


### PR DESCRIPTION
**Background**
In the k8s deployed pod, even though pip install command passed, but peft didn't be installed.
It's hard to debug, the simplest way is to specify required packages in requirements_moreh.txt; 

```
[base] [2024-01-30 16:55:58,787] [[0;32mINFO[0m] Traceback (most recent call last):
[base] [2024-01-30 16:55:58,788] [[0;32mINFO[0m]   File "examples/scripts/reward_trainer.py", line 21, in <module>
[base] [2024-01-30 16:55:58,789] [[0;32mINFO[0m]     from peft import LoraConfig
[base] [2024-01-30 16:55:58,789] [[0;32mINFO[0m] ModuleNotFoundError: No module named 'peft'
```
