### PR TITLE
Update setuptools to 69.5.1

### DIFF
--- a/requirements_moreh.txt
+++ b/requirements_moreh.txt
@@ -4,7 +4,7 @@ diffusers>=0.21.2
 tqdm==4.65.2
 transformers==4.29.2
 sentencepiece==0.1.99
-setuptools==65.5.0
+setuptools==69.5.1
 accelerate==0.21.0
 peft==0.5.0
 tyro>=0.5.7


### PR DESCRIPTION
## Background
Our latest `moreh_driver` (version `24.8.3020`) on Nexus requires `setuptools` version `69.5.1`. However, our benchmarks are currently using `setuptools` version `65.5.0`, as specified in our `requirements_moreh.txt` file, which is causing compatibility issues.

## Contents
- Update `setuptools` to `69.5.1`.